### PR TITLE
Report error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ORG=integreatly
 PROJECT=grafana_plugins_init
 REG=quay.io
-TAG=0.0.3
+TAG=0.0.4
 PKG=github.com/integr8ly/grafana_plugins_init
 
 .PHONY: image/build

--- a/plugins.py
+++ b/plugins.py
@@ -49,8 +49,8 @@ def extractPlugin(file_name):
 def installPlugin(plugin):
     try:
         file_name = downloadPlugin(plugin)
-    except:
-        print("Error downloading %s:%s" % plugin)
+    except Exception as err:
+        print("Error downloading %s:%s: %s" % (*plugin, err))
     else:
         extractPlugin(file_name)
 


### PR DESCRIPTION
This prints the error message when something goes wrong.

Demo:
```
% GRAFANA_PLUGINS=not-a-valid-plugin:x.x.x python plugins.py
Error downloading not-a-valid-plugin:x.x.x: HTTP Error 404: Not Found
```