### PR TITLE
Add image/buildx cmd and bump version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
 ORG=integreatly
 PROJECT=grafana_plugins_init
 REG=quay.io
-TAG=0.0.4
+TAG=0.0.5
 PKG=github.com/integr8ly/grafana_plugins_init
 
 .PHONY: image/build
 image/build:
 	docker build -t ${REG}/${ORG}/${PROJECT}:${TAG} .
+
+# Build and push a multi-architecture docker image
+.PHONY: image/buildx
+image/buildx:
+	docker buildx build --platform linux/amd64,linux/arm64,linux/s390x --push -t ${REG}/${ORG}/${PROJECT}:${TAG} .
 
 .PHONY: image/push
 image/push:


### PR DESCRIPTION
Init container build for https://github.com/grafana-operator/grafana-operator/issues/541

Output of `make image/buildx`

```
docker buildx build --platform linux/amd64,linux/arm64,linux/s390x --push -t quay.io/integreatly/grafana_plugins_init:0.0.5 .
[+] Building 33.4s (14/14) FINISHED
 => [internal] booting buildkit                                                                                                                                                                           14.1s
 => => pulling image moby/buildkit:buildx-stable-1                                                                                                                                                        13.2s
 => => creating container buildx_buildkit_fervent_napier0                                                                                                                                                  0.9s
 => [internal] load build definition from Dockerfile                                                                                                                                                       0.0s
 => => transferring dockerfile: 111B                                                                                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                            0.0s
 => [linux/s390x internal] load metadata for docker.io/library/python:3-alpine                                                                                                                             2.7s
 => [linux/arm64 internal] load metadata for docker.io/library/python:3-alpine                                                                                                                             2.8s
 => [linux/amd64 internal] load metadata for docker.io/library/python:3-alpine                                                                                                                             2.6s
 => [internal] load build context                                                                                                                                                                          0.1s
 => => transferring context: 1.79kB                                                                                                                                                                        0.0s
 => [linux/s390x 1/2] FROM docker.io/library/python:3-alpine@sha256:78604a29496b7a1bd5ea5c985d69a0928db7ea32fcfbf71bbde3e317fdd9ac5e                                                                       6.9s
 => => resolve docker.io/library/python:3-alpine@sha256:78604a29496b7a1bd5ea5c985d69a0928db7ea32fcfbf71bbde3e317fdd9ac5e                                                                                   0.0s
 => => sha256:61e513b757725c78f2c363853ef376bc0e7fb27baf9a5e19e52f9fc7a457fac2 11.60MB / 11.60MB                                                                                                           6.2s
 => => sha256:75174569b3affb54f21b280453469a05d26542303e3ec1fa4f87459fef7970d4 2.35MB / 2.35MB                                                                                                             1.4s
 => => sha256:798844f2ac3ce333d49075582ab558b00ab44e20965b95f5c483dba412e5c678 661.82kB / 661.82kB                                                                                                         0.6s
 => => sha256:da14cb6b6dc946dbb2d84386bcaca84e2d46f650767cd11bdb3331ec9d623988 2.60MB / 2.60MB                                                                                                             1.4s
 => => extracting sha256:da14cb6b6dc946dbb2d84386bcaca84e2d46f650767cd11bdb3331ec9d623988                                                                                                                  0.1s
 => => extracting sha256:798844f2ac3ce333d49075582ab558b00ab44e20965b95f5c483dba412e5c678                                                                                                                  0.3s
 => => extracting sha256:61e513b757725c78f2c363853ef376bc0e7fb27baf9a5e19e52f9fc7a457fac2                                                                                                                  0.5s
 => => extracting sha256:0c25379c6b7426aac2e10545e2a4fa4e1dd6580359f02fb424a1f0b5efc45ae2                                                                                                                  0.0s
 => => extracting sha256:75174569b3affb54f21b280453469a05d26542303e3ec1fa4f87459fef7970d4                                                                                                                  0.2s
 => [linux/amd64 1/2] FROM docker.io/library/python:3-alpine@sha256:78604a29496b7a1bd5ea5c985d69a0928db7ea32fcfbf71bbde3e317fdd9ac5e                                                                       8.4s
 => => resolve docker.io/library/python:3-alpine@sha256:78604a29496b7a1bd5ea5c985d69a0928db7ea32fcfbf71bbde3e317fdd9ac5e                                                                                   0.0s
 => => sha256:8fec21e4ed42c2b57ba40ee43ac8399b9a9b12782be3a42482bd98b8791d0be5 230B / 230B                                                                                                                 0.3s
 => => sha256:5cb87e8bc1a2b59592911a6a4dc2d04a75f6051c74a61c1b25994a816e441fd0 2.35MB / 2.35MB                                                                                                             1.5s
 => => sha256:a0d0a0d46f8b52473982a3c466318f479767577551a53ffc9074c9fa7035982e 2.81MB / 2.81MB                                                                                                             1.7s
 => => sha256:5ed3eaf4d331baca892656a7bc924f24b3cb740ff90079dbc609092327835100 11.64MB / 11.64MB                                                                                                           3.7s
 => => extracting sha256:a0d0a0d46f8b52473982a3c466318f479767577551a53ffc9074c9fa7035982e                                                                                                                  0.1s
 => => sha256:ba51967de001c6e85f574865082c7306be70f40d685b22a82fb7577a67506548 656.38kB / 656.38kB                                                                                                         0.6s
 => => extracting sha256:ba51967de001c6e85f574865082c7306be70f40d685b22a82fb7577a67506548                                                                                                                  0.3s
 => => extracting sha256:5ed3eaf4d331baca892656a7bc924f24b3cb740ff90079dbc609092327835100                                                                                                                  0.4s
 => => extracting sha256:8fec21e4ed42c2b57ba40ee43ac8399b9a9b12782be3a42482bd98b8791d0be5                                                                                                                  0.0s
 => => extracting sha256:5cb87e8bc1a2b59592911a6a4dc2d04a75f6051c74a61c1b25994a816e441fd0                                                                                                                  0.2s
 => [linux/arm64 1/2] FROM docker.io/library/python:3-alpine@sha256:78604a29496b7a1bd5ea5c985d69a0928db7ea32fcfbf71bbde3e317fdd9ac5e                                                                       7.5s
 => => resolve docker.io/library/python:3-alpine@sha256:78604a29496b7a1bd5ea5c985d69a0928db7ea32fcfbf71bbde3e317fdd9ac5e                                                                                   0.0s
 => => sha256:59c486883b7a190c67f428a912b56e67b312b4714c5d472e30634685f9bce741 2.35MB / 2.35MB                                                                                                             1.3s
 => => sha256:42b4f2479df6ac1fd21949a95fb1e5b0f458b46c24345bcc73168217fccde3a6 11.70MB / 11.70MB                                                                                                           5.4s
 => => sha256:84acdbdf1fe03fd0ce92c771f509277913b60408314d37314f5f8f316b2058c6 229B / 229B                                                                                                                 0.2s
 => => sha256:0e41ad7c31f908109dc305802a72de4a02faf0f46b22f5fadd98430098be7a30 679.46kB / 679.46kB                                                                                                         0.7s
 => => sha256:552d1f2373af9bfe12033568ebbfb0ccbb0de11279f9a415a29207e264d7f4d9 2.71MB / 2.71MB                                                                                                             1.4s
 => => extracting sha256:552d1f2373af9bfe12033568ebbfb0ccbb0de11279f9a415a29207e264d7f4d9                                                                                                                  0.1s
 => => extracting sha256:0e41ad7c31f908109dc305802a72de4a02faf0f46b22f5fadd98430098be7a30                                                                                                                  0.2s
 => => extracting sha256:42b4f2479df6ac1fd21949a95fb1e5b0f458b46c24345bcc73168217fccde3a6                                                                                                                  0.5s
 => => extracting sha256:84acdbdf1fe03fd0ce92c771f509277913b60408314d37314f5f8f316b2058c6                                                                                                                  0.0s
 => => extracting sha256:59c486883b7a190c67f428a912b56e67b312b4714c5d472e30634685f9bce741                                                                                                                  0.2s
 => [linux/s390x 2/2] COPY plugins.py ./                                                                                                                                                                   0.2s
 => [linux/arm64 2/2] COPY plugins.py ./                                                                                                                                                                   0.1s
 => [linux/amd64 2/2] COPY plugins.py ./                                                                                                                                                                   0.1s
 => ERROR exporting to image                                                                                                                                                                               6.8s
 => => exporting layers                                                                                                                                                                                    0.4s
 => => exporting manifest sha256:f832fb03f80ea8255dd57560b4aa6ca5e2de36dc5b57913b22d6e8d8e4ebfa0a                                                                                                          0.0s
 => => exporting config sha256:cc106b13d0fae8496ec5e22f944871a0e7dcce7f8ab3bd92350e7038f4daff2d                                                                                                            0.0s
 => => exporting manifest sha256:6d8ff8e5316bc270a947667e5142845f33dab7a37d46dfa9efa86109badf55ec                                                                                                          0.0s
 => => exporting config sha256:a0cf55391116356c3785dbb24bbc34867ddcbaa46168b249e15f203ff32a6a2f                                                                                                            0.0s
 => => exporting manifest sha256:4dd8e201632db0607eb2622f64e393baa16dd480f1487e506f1221c8ec14de7e                                                                                                          0.0s
 => => exporting config sha256:ae2d83888efcb5cd9d609fbbe0e89caa39c77f7993a30a344453e10ebee1d18d                                                                                                            0.0s
 => => exporting manifest list sha256:4eb1945323b0283f38d95d3158d6671c814512f2bfb955d363b6b805d75f06b6                                                                                                     0.0s
 => => pushing layers                                                                                                                                                                                      6.4s
------
 > exporting to image:
------
error: failed to solve: unexpected status: 401 UNAUTHORIZED
make: *** [image/buildx] Error 1
```
I suspect the 401 is because I'm missing permissions on the quay org, but the rest of the output looks reasonable.