### PR TITLE
include arch and os in download parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:3-alpine
 
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV OS=${TARGETOS}
+ENV ARCH=${TARGETARCH}
+
 COPY plugins.py ./
 
 CMD [ "python", "./plugins.py"]

--- a/plugins.py
+++ b/plugins.py
@@ -4,9 +4,12 @@ import os
 import zipfile
 import urllib.request
 import shutil
+import platform
 
 pluginsKey = "GRAFANA_PLUGINS"
 pluginsVolume = "/opt/plugins"
+ARCH = os.environ.get("ARCH", platform.machine())
+OS = os.environ.get("OS", platform.system().lower())
 
 
 class ZipFileWithPermissions(zipfile.ZipFile):
@@ -38,7 +41,8 @@ def getPlugins():
 
 
 def downloadPlugin(plugin):
-    url = "https://grafana.com/api/plugins/%s/versions/%s/download" % plugin
+    name, version = plugin
+    url = f"https://grafana.com/api/plugins/{name}/versions/{version}/download?os={OS}&arch={ARCH}"
     file_name = "/tmp/%s_%s.zip" % plugin
     with urllib.request.urlopen(url) as response, open(file_name, "wb") as out_file:
         shutil.copyfileobj(response, out_file)

--- a/plugins.py
+++ b/plugins.py
@@ -44,12 +44,14 @@ def downloadPlugin(plugin):
     name, version = plugin
     url = f"https://grafana.com/api/plugins/{name}/versions/{version}/download?os={OS}&arch={ARCH}"
     file_name = "/tmp/%s_%s.zip" % plugin
+    print(f"downloading {url}")
     with urllib.request.urlopen(url) as response, open(file_name, "wb") as out_file:
         shutil.copyfileobj(response, out_file)
     return file_name
 
 
 def extractPlugin(file_name):
+    print(f"extracting {file_name}")
     zip = ZipFileWithPermissions(file_name)
     zip.extractall(pluginsVolume)
     zip.close()
@@ -67,6 +69,7 @@ def installPlugin(plugin):
 def main():
     for plugin in getPlugins():
         installPlugin(plugin)
+    print("done")
 
 
 main()


### PR DESCRIPTION
Some plugin downloads now require specifying the arch and os. Example error:
```
Error downloading grafana-googlesheets-datasource:1.1.1

% curl https://grafana.com/api/plugins/grafana-googlesheets-datasource/versions/1.1.1/download
{
  "code": "BadRequest",
  "message": "You must specify the os and architecture to download this plugin"
}
```
It must be downloaded like this:
```
% curl "https://grafana.com/api/plugins/grafana-googlesheets-datasource/versions/1.1.1/download?os=linux&arch=amd64"
{
  "url": "https://storage.googleapis.com/integration-artifacts/grafana-googlesheets-datasource/release/1.1.1/linux/grafana-googlesheets-datasource-1.1.1.linux_amd64.zip",
  "downloads": 523
}
```
Downloads that don't require it treat these query parameters as optional, so it's safe everywhere:
```
% curl "https://grafana.com/api/plugins/ae3e-plotly-panel/versions/0.3.3/download"
{
  "url": "https://storage.googleapis.com/plugins-community/ae3e-plotly-panel/release/0.3.3/ae3e-plotly-panel-0.3.3.zip",
  "downloads": 39973
}
% curl "https://grafana.com/api/plugins/ae3e-plotly-panel/versions/0.3.3/download?os=linux&arch=amd64"
{
  "url": "https://storage.googleapis.com/plugins-community/ae3e-plotly-panel/release/0.3.3/ae3e-plotly-panel-0.3.3.zip",
  "downloads": 39969
}
```
This PR sets the ARCH and OS at build time via the Dockerfile, then includes those values in the download URL parameters.